### PR TITLE
Switch to easyfft to simplify logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 
 [dependencies]
 num = "0.4.0"
-rustfft = "6.1.0"
 hound = "3.5.0"
 apodize = "1.0.0"
 clap = { version = "4.0.32", features = ["derive"] }
+easyfft = "0.3.3"


### PR DESCRIPTION
Consider using the`easyfft` wrapper instead of `rustfft` directly. This simplifies the logic by not caring about the planner struct.